### PR TITLE
[codex] Implement analytics events endpoint

### DIFF
--- a/app/Http/Controllers/Api/ProductAnalyticsEventController.php
+++ b/app/Http/Controllers/Api/ProductAnalyticsEventController.php
@@ -15,10 +15,9 @@ class ProductAnalyticsEventController extends Controller
 
     public function store(StoreProductAnalyticsEventRequest $request): JsonResponse
     {
-        $event = $this->events->store($request->validated());
+        $this->events->store($request->validated());
 
         return response()->json([
-            'id' => $event->id,
             'status' => 'accepted',
         ], 201);
     }

--- a/app/Http/Controllers/Api/ProductAnalyticsEventController.php
+++ b/app/Http/Controllers/Api/ProductAnalyticsEventController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreProductAnalyticsEventRequest;
+use App\Services\Analytics\ProductAnalyticsEventService;
+use Illuminate\Http\JsonResponse;
+
+class ProductAnalyticsEventController extends Controller
+{
+    public function __construct(
+        private readonly ProductAnalyticsEventService $events,
+    ) {}
+
+    public function store(StoreProductAnalyticsEventRequest $request): JsonResponse
+    {
+        $event = $this->events->store($request->validated());
+
+        return response()->json([
+            'id' => $event->id,
+            'status' => 'accepted',
+        ], 201);
+    }
+}

--- a/app/Http/Requests/StoreProductAnalyticsEventRequest.php
+++ b/app/Http/Requests/StoreProductAnalyticsEventRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Services\Analytics\ProductAnalyticsEventService;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreProductAnalyticsEventRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $identifier = 'regex:/^[A-Za-z0-9_.:-]+$/';
+
+        return [
+            'project' => ['required', 'string', 'max:80', $identifier],
+            'event_name' => ['required', 'string', Rule::in(ProductAnalyticsEventService::ALLOWED_EVENTS)],
+            'feature' => ['nullable', 'string', 'max:80', $identifier],
+            'source' => ['nullable', 'string', 'max:120', $identifier],
+            'destination' => ['nullable', 'string', 'max:120', $identifier],
+            'page_path' => ['nullable', 'string', 'max:255', 'regex:/^\/[A-Za-z0-9\/_.-]*$/'],
+            'session_id' => ['nullable', 'string', 'max:80', 'regex:/^[A-Za-z0-9_.:-]+$/'],
+            'metadata' => ['nullable', 'array'],
+            'occurred_at' => ['nullable', 'date'],
+        ];
+    }
+}

--- a/app/Models/ProductAnalyticsEvent.php
+++ b/app/Models/ProductAnalyticsEvent.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ProductAnalyticsEvent extends Model
+{
+    protected $fillable = [
+        'project',
+        'event_name',
+        'feature',
+        'source',
+        'destination',
+        'page_path',
+        'session_id',
+        'metadata',
+        'occurred_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'metadata' => 'array',
+            'occurred_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,8 +2,11 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\ServiceProvider;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -21,5 +24,9 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Schema::defaultStringLength(191);
+
+        RateLimiter::for('analytics-events', function (Request $request) {
+            return Limit::perMinute(30)->by($request->ip());
+        });
     }
 }

--- a/app/Services/Analytics/ProductAnalyticsEventService.php
+++ b/app/Services/Analytics/ProductAnalyticsEventService.php
@@ -45,6 +45,7 @@ class ProductAnalyticsEventService
     public function store(array $payload): ProductAnalyticsEvent
     {
         $payload['metadata'] = $this->sanitizeMetadata($payload['metadata'] ?? []);
+        $payload['occurred_at'] ??= now();
 
         return ProductAnalyticsEvent::create($payload);
     }

--- a/app/Services/Analytics/ProductAnalyticsEventService.php
+++ b/app/Services/Analytics/ProductAnalyticsEventService.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Services\Analytics;
+
+use App\Models\ProductAnalyticsEvent;
+use Illuminate\Validation\ValidationException;
+
+class ProductAnalyticsEventService
+{
+    public const ALLOWED_EVENTS = [
+        'page_viewed',
+        'cta_clicked',
+        'tool_card_clicked',
+        'project_card_clicked',
+        'tool_opened',
+        'tool_result_copied',
+        'tool_example_used',
+        'tool_cleared',
+    ];
+
+    private const FORBIDDEN_METADATA_KEYS = [
+        'base64',
+        'content',
+        'email',
+        'hash',
+        'input',
+        'json',
+        'name',
+        'output',
+        'payload',
+        'phone',
+        'query',
+        'result',
+        'text',
+        'url',
+        'value',
+    ];
+
+    private const MAX_METADATA_ITEMS = 10;
+
+    private const MAX_METADATA_STRING_LENGTH = 120;
+
+    private const MAX_METADATA_JSON_BYTES = 2048;
+
+    public function store(array $payload): ProductAnalyticsEvent
+    {
+        $payload['metadata'] = $this->sanitizeMetadata($payload['metadata'] ?? []);
+
+        return ProductAnalyticsEvent::create($payload);
+    }
+
+    /**
+     * @param  array<string, mixed>  $metadata
+     * @return array<string, bool|float|int|string|null>
+     */
+    private function sanitizeMetadata(array $metadata): array
+    {
+        if (count($metadata) > self::MAX_METADATA_ITEMS) {
+            $this->fail('Metadata supports up to '.self::MAX_METADATA_ITEMS.' items.');
+        }
+
+        $sanitized = [];
+
+        foreach ($metadata as $key => $value) {
+            if (! is_string($key) || ! preg_match('/^[a-zA-Z0-9_.-]{1,40}$/', $key)) {
+                $this->fail('Metadata keys must be short identifiers.');
+            }
+
+            if ($this->isForbiddenKey($key)) {
+                $this->fail('Metadata contains a forbidden key.');
+            }
+
+            if (! is_null($value) && ! is_bool($value) && ! is_int($value) && ! is_float($value) && ! is_string($value)) {
+                $this->fail('Metadata values must be scalar.');
+            }
+
+            if (is_string($value)) {
+                $value = trim($value);
+
+                if ($this->looksSensitive($value)) {
+                    $this->fail('Metadata contains sensitive content.');
+                }
+
+                if (mb_strlen($value) > self::MAX_METADATA_STRING_LENGTH) {
+                    $value = mb_substr($value, 0, self::MAX_METADATA_STRING_LENGTH);
+                }
+
+                if (! preg_match('/^[A-Za-z0-9_.:\/-]*$/', $value)) {
+                    $this->fail('Metadata string values must be controlled identifiers.');
+                }
+            }
+
+            $sanitized[$key] = $value;
+        }
+
+        $encoded = json_encode($sanitized, JSON_THROW_ON_ERROR);
+
+        if (strlen($encoded) > self::MAX_METADATA_JSON_BYTES) {
+            $this->fail('Metadata payload is too large.');
+        }
+
+        return $sanitized;
+    }
+
+    private function isForbiddenKey(string $key): bool
+    {
+        $normalized = strtolower($key);
+
+        foreach (self::FORBIDDEN_METADATA_KEYS as $forbiddenKey) {
+            if (str_contains($normalized, $forbiddenKey)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function looksSensitive(string $value): bool
+    {
+        if ($value === '') {
+            return false;
+        }
+
+        if (filter_var($value, FILTER_VALIDATE_EMAIL)) {
+            return true;
+        }
+
+        if (preg_match('/https?:\/\/|www\.|[a-z0-9.-]+\.[a-z]{2,}/i', $value)) {
+            return true;
+        }
+
+        if (preg_match('/\+?\d[\d\s().-]{7,}\d/', $value)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function fail(string $message): never
+    {
+        throw ValidationException::withMessages([
+            'metadata' => [$message],
+        ]);
+    }
+}

--- a/database/migrations/2026_06_30_000000_create_product_analytics_events_table.php
+++ b/database/migrations/2026_06_30_000000_create_product_analytics_events_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('product_analytics_events', function (Blueprint $table) {
+            $table->id();
+            $table->string('project', 80);
+            $table->string('event_name', 80);
+            $table->string('feature', 80)->nullable();
+            $table->string('source', 120)->nullable();
+            $table->string('destination', 120)->nullable();
+            $table->string('page_path')->nullable();
+            $table->string('session_id', 80)->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamp('occurred_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['project', 'event_name']);
+            $table->index('occurred_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('product_analytics_events');
+    }
+};

--- a/docs/analytics-events.md
+++ b/docs/analytics-events.md
@@ -75,7 +75,6 @@ Resposta:
 
 ```json
 {
-  "id": 1,
   "status": "accepted"
 }
 ```

--- a/docs/analytics-events.md
+++ b/docs/analytics-events.md
@@ -1,0 +1,85 @@
+# Analytics events endpoint
+
+Endpoint publico para receber eventos anonimos de produto da Rock Code Labs.
+
+## Rota
+
+`POST /api/analytics/events`
+
+Rate limit: 30 requisicoes por minuto por origem.
+
+## Eventos permitidos
+
+- `page_viewed`
+- `cta_clicked`
+- `tool_card_clicked`
+- `project_card_clicked`
+- `tool_opened`
+- `tool_result_copied`
+- `tool_example_used`
+- `tool_cleared`
+
+## Campos aceitos
+
+| Campo | Obrigatorio | Regra |
+| --- | --- | --- |
+| `project` | Sim | Identificador controlado, ate 80 caracteres. |
+| `event_name` | Sim | Deve estar na allowlist de eventos. |
+| `feature` | Nao | Identificador controlado, ate 80 caracteres. |
+| `source` | Nao | Identificador controlado, ate 120 caracteres. |
+| `destination` | Nao | Identificador controlado, ate 120 caracteres. |
+| `page_path` | Nao | Caminho interno iniciado por `/`, sem query string. |
+| `session_id` | Nao | Identificador anonimo, ate 80 caracteres. |
+| `metadata` | Nao | Objeto plano com ate 10 itens escalares. |
+| `occurred_at` | Nao | Data/hora parseavel pelo Laravel. |
+
+Identificadores controlados aceitam letras, numeros, `_`, `.`, `:` e `-`.
+
+## Metadata
+
+`metadata` e opcional e deve ser usada apenas para valores controlados pelo produto, como variante, posicao ou modo da interface.
+
+Regras:
+
+- ate 10 chaves;
+- chaves com ate 40 caracteres;
+- valores somente `string`, `number`, `boolean` ou `null`;
+- strings sao truncadas em 120 caracteres;
+- payload final de metadata limitado a 2 KB;
+- strings de metadata nao aceitam espacos nem texto livre.
+
+Chaves com termos sensiveis sao rejeitadas, incluindo `input`, `output`, `text`, `content`, `payload`, `json`, `base64`, `hash`, `url`, `email`, `phone`, `name`, `query`, `result` e `value`.
+
+Valores com e-mail, URL ou telefone tambem sao rejeitados.
+
+## Exemplo aceito
+
+```json
+{
+  "project": "rockcode-site",
+  "event_name": "cta_clicked",
+  "feature": "home",
+  "source": "hero",
+  "destination": "contact_cta",
+  "page_path": "/",
+  "session_id": "session-123",
+  "metadata": {
+    "variant": "primary",
+    "position": 1
+  },
+  "occurred_at": "2026-06-30T12:00:00Z"
+}
+```
+
+Resposta:
+
+```json
+{
+  "id": 1,
+  "status": "accepted"
+}
+```
+
+## Dados proibidos
+
+Nao enviar nem persistir input digitado, output gerado, JSON colado, Base64, hashes, URLs digitadas em ferramentas, texto livre, e-mail, telefone, nome, dados pessoais ou fingerprinting.

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,10 +1,14 @@
-<?php 
+<?php
 
+use App\Http\Controllers\Api\ProductAnalyticsEventController;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/messages', function() {
-    return  response()->json([
+Route::get('/messages', function () {
+    return response()->json([
         ['id' => 1, 'text' => 'Bem vindo a rockcode labs.'],
-        ['id' => 2, 'text' => 'API Laravel Conectada com sucesso.']
+        ['id' => 2, 'text' => 'API Laravel Conectada com sucesso.'],
     ]);
 });
+
+Route::post('/analytics/events', [ProductAnalyticsEventController::class, 'store'])
+    ->middleware('throttle:analytics-events');

--- a/tests/Feature/ProductAnalyticsEventTest.php
+++ b/tests/Feature/ProductAnalyticsEventTest.php
@@ -46,10 +46,29 @@ class ProductAnalyticsEventTest extends TestCase
 
         $event = ProductAnalyticsEvent::query()->firstOrFail();
 
+        $response->assertJsonMissing([
+            'id' => $event->id,
+        ]);
+
         $this->assertSame([
             'variant' => 'primary',
             'position' => 1,
         ], $event->metadata);
+    }
+
+    public function test_event_without_occurred_at_uses_server_time(): void
+    {
+        $this->travelTo('2026-06-30 12:00:00');
+
+        $this->postJson('/api/analytics/events', [
+            'project' => 'rockcode-site',
+            'event_name' => 'page_viewed',
+            'page_path' => '/',
+        ])->assertCreated();
+
+        $event = ProductAnalyticsEvent::query()->firstOrFail();
+
+        $this->assertSame('2026-06-30 12:00:00', $event->occurred_at->format('Y-m-d H:i:s'));
     }
 
     public function test_disallowed_event_is_rejected(): void
@@ -71,6 +90,76 @@ class ProductAnalyticsEventTest extends TestCase
             'event_name' => 'tool_opened',
             'metadata' => [
                 'user_email' => 'cliente@example.com',
+            ],
+        ]);
+
+        $response->assertUnprocessable();
+
+        $this->assertDatabaseCount('product_analytics_events', 0);
+    }
+
+    public function test_nested_metadata_is_rejected(): void
+    {
+        $response = $this->postJson('/api/analytics/events', [
+            'project' => 'rockcode-site',
+            'event_name' => 'tool_opened',
+            'metadata' => [
+                'tool' => [
+                    'id' => 'base64',
+                ],
+            ],
+        ]);
+
+        $response->assertUnprocessable();
+
+        $this->assertDatabaseCount('product_analytics_events', 0);
+    }
+
+    public function test_page_path_with_query_string_is_rejected(): void
+    {
+        $response = $this->postJson('/api/analytics/events', [
+            'project' => 'rockcode-site',
+            'event_name' => 'page_viewed',
+            'page_path' => '/ferramentas/base64?input=abc',
+        ]);
+
+        $response->assertUnprocessable();
+
+        $this->assertDatabaseCount('product_analytics_events', 0);
+    }
+
+    public function test_metadata_url_value_is_rejected(): void
+    {
+        $response = $this->postJson('/api/analytics/events', [
+            'project' => 'rockcode-site',
+            'event_name' => 'tool_opened',
+            'metadata' => [
+                'target' => 'https://example.com',
+            ],
+        ]);
+
+        $response->assertUnprocessable();
+
+        $this->assertDatabaseCount('product_analytics_events', 0);
+    }
+
+    public function test_metadata_with_more_than_ten_items_is_rejected(): void
+    {
+        $response = $this->postJson('/api/analytics/events', [
+            'project' => 'rockcode-site',
+            'event_name' => 'tool_opened',
+            'metadata' => [
+                'item_1' => 1,
+                'item_2' => 2,
+                'item_3' => 3,
+                'item_4' => 4,
+                'item_5' => 5,
+                'item_6' => 6,
+                'item_7' => 7,
+                'item_8' => 8,
+                'item_9' => 9,
+                'item_10' => 10,
+                'item_11' => 11,
             ],
         ]);
 

--- a/tests/Feature/ProductAnalyticsEventTest.php
+++ b/tests/Feature/ProductAnalyticsEventTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ProductAnalyticsEvent;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\RateLimiter;
+use Tests\TestCase;
+
+class ProductAnalyticsEventTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_allowed_event_is_persisted(): void
+    {
+        $response = $this->postJson('/api/analytics/events', [
+            'project' => 'rockcode-site',
+            'event_name' => 'cta_clicked',
+            'feature' => 'home',
+            'source' => 'hero',
+            'destination' => 'contact_cta',
+            'page_path' => '/',
+            'session_id' => 'session-123',
+            'metadata' => [
+                'variant' => 'primary',
+                'position' => 1,
+            ],
+            'occurred_at' => '2026-06-30T12:00:00Z',
+        ]);
+
+        $response
+            ->assertCreated()
+            ->assertJson([
+                'status' => 'accepted',
+            ]);
+
+        $this->assertDatabaseHas('product_analytics_events', [
+            'project' => 'rockcode-site',
+            'event_name' => 'cta_clicked',
+            'feature' => 'home',
+            'source' => 'hero',
+            'destination' => 'contact_cta',
+            'page_path' => '/',
+            'session_id' => 'session-123',
+        ]);
+
+        $event = ProductAnalyticsEvent::query()->firstOrFail();
+
+        $this->assertSame([
+            'variant' => 'primary',
+            'position' => 1,
+        ], $event->metadata);
+    }
+
+    public function test_disallowed_event_is_rejected(): void
+    {
+        $response = $this->postJson('/api/analytics/events', [
+            'project' => 'rockcode-site',
+            'event_name' => 'typed_tool_input',
+        ]);
+
+        $response->assertUnprocessable();
+
+        $this->assertDatabaseCount('product_analytics_events', 0);
+    }
+
+    public function test_sensitive_metadata_is_rejected(): void
+    {
+        $response = $this->postJson('/api/analytics/events', [
+            'project' => 'rockcode-site',
+            'event_name' => 'tool_opened',
+            'metadata' => [
+                'user_email' => 'cliente@example.com',
+            ],
+        ]);
+
+        $response->assertUnprocessable();
+
+        $this->assertDatabaseCount('product_analytics_events', 0);
+    }
+
+    public function test_analytics_events_are_rate_limited(): void
+    {
+        RateLimiter::clear('127.0.0.1');
+
+        for ($attempt = 1; $attempt <= 30; $attempt++) {
+            $this->postJson('/api/analytics/events', [
+                'project' => 'rockcode-site',
+                'event_name' => 'page_viewed',
+                'page_path' => '/',
+            ])->assertCreated();
+        }
+
+        $this->postJson('/api/analytics/events', [
+            'project' => 'rockcode-site',
+            'event_name' => 'page_viewed',
+            'page_path' => '/',
+        ])->assertTooManyRequests();
+    }
+}


### PR DESCRIPTION
## Contexto

Closes #2.

Implementa o backend minimo de analytics de produto para receber eventos publicos e anonimos do frontend da Rock Code Labs, sem persistir conteudo digitado, saidas de ferramentas, dados pessoais ou fingerprinting.

## O que mudou

- Criado endpoint `POST /api/analytics/events`.
- Adicionada tabela `product_analytics_events` para persistencia dos eventos permitidos.
- Adicionada allowlist inicial de eventos:
  - `page_viewed`
  - `cta_clicked`
  - `tool_card_clicked`
  - `project_card_clicked`
  - `tool_opened`
  - `tool_result_copied`
  - `tool_example_used`
  - `tool_cleared`
- Adicionada validacao de payload por `FormRequest`.
- Adicionada sanitizacao de metadata com bloqueio de chaves e valores sensiveis.
- Adicionado rate limit nomeado `analytics-events` com 30 requisicoes por minuto por origem.
- `occurred_at` agora e preenchido com `now()` no backend quando o frontend nao envia o campo.
- A resposta publica retorna apenas `{ status: accepted }`, sem expor ID incremental.
- Documentado o contrato em `docs/analytics-events.md`.
- Adicionados testes de feature para persistencia, evento invalido, metadata sensivel, metadata aninhada, `page_path` com query string, valor URL em metadata, metadata com mais de 10 itens, fallback de `occurred_at` e rate limit.

## Regras de seguranca e privacidade

O endpoint aceita somente identificadores controlados nos campos textuais principais e metadata plana com valores escalares. Chaves relacionadas a `input`, `output`, `text`, `content`, `json`, `base64`, `hash`, `url`, `email`, `phone`, `name`, `query`, `result`, `payload` e `value` sao rejeitadas. Valores que parecem e-mail, URL ou telefone tambem sao rejeitados.

## Follow-up dos apontamentos

- Resolvido o ajuste recomendado de Data/Analytics: `occurred_at` nao fica mais nulo quando ausente.
- Executada a sugestao de Security/Data de nao retornar ID incremental no endpoint publico.
- Adicionados testes extras de privacidade sugeridos nas revisoes.
- Mantidos como follow-up operacional: validar CORS, trusted proxies/Cloudflare/Nginx e estrategia de rotacao do `session_id` no ambiente real.

## Validacao automatizada

- `php artisan test --filter=ProductAnalyticsEventTest`
- `php artisan test`
- `vendor\bin\pint --dirty`
- `git diff --cached --check`

Observacao: os testes passaram, mas o ambiente local emitiu aviso de Xdebug por nao conseguir abrir `c:/wamp64/logs/xdebug.log`.

## Roteiro manual breve

1. Rodar as migrations no ambiente alvo.
2. Enviar um `POST /api/analytics/events` com `event_name: cta_clicked` e metadata controlada.
3. Confirmar resposta `201`, corpo `{ status: accepted }` e persistencia em `product_analytics_events`.
4. Enviar um evento sem `occurred_at` e confirmar preenchimento pelo backend.
5. Repetir com evento fora da allowlist e confirmar resposta `422`.
6. Repetir com metadata contendo e-mail, URL, objeto aninhado ou chave sensivel e confirmar resposta `422`.

## Revisores recomendados

- `[RockCodeLabs][CTO]`
- `[RockCodeLabs][Security]`
- `[RockCodeLabs][Data/Analytics]`