### PR TITLE
Add minimal admin analytics dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ APP_DEBUG=true
 APP_URL=http://localhost
 TRUSTED_PROXIES=
 CORS_ALLOWED_ORIGINS=https://rockcodelabs.com.br,https://www.rockcodelabs.com.br
+ADMIN_USERNAME=
+ADMIN_PASSWORD=
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en

--- a/app/Http/Controllers/Admin/ProductAnalyticsDashboardController.php
+++ b/app/Http/Controllers/Admin/ProductAnalyticsDashboardController.php
@@ -23,7 +23,7 @@ class ProductAnalyticsDashboardController extends Controller
             'summary' => $dashboard->summarize($periodDays),
             'periods' => self::ALLOWED_PERIODS,
         ])->withHeaders([
-            'Cache-Control' => 'no-store, no-cache, must-revalidate',
+            'Cache-Control' => 'must-revalidate, no-cache, no-store, private',
             'Pragma' => 'no-cache',
             'X-Robots-Tag' => 'noindex, nofollow, noarchive',
         ]);

--- a/app/Http/Controllers/Admin/ProductAnalyticsDashboardController.php
+++ b/app/Http/Controllers/Admin/ProductAnalyticsDashboardController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Services\Analytics\ProductAnalyticsDashboardService;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class ProductAnalyticsDashboardController extends Controller
+{
+    private const ALLOWED_PERIODS = [7, 30, 90];
+
+    public function __invoke(Request $request, ProductAnalyticsDashboardService $dashboard): View
+    {
+        $periodDays = (int) $request->integer('period', 30);
+
+        if (! in_array($periodDays, self::ALLOWED_PERIODS, true)) {
+            $periodDays = 30;
+        }
+
+        return view('admin.analytics-dashboard', [
+            'summary' => $dashboard->summarize($periodDays),
+            'periods' => self::ALLOWED_PERIODS,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Admin/ProductAnalyticsDashboardController.php
+++ b/app/Http/Controllers/Admin/ProductAnalyticsDashboardController.php
@@ -5,13 +5,13 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Services\Analytics\ProductAnalyticsDashboardService;
 use Illuminate\Http\Request;
-use Illuminate\View\View;
+use Illuminate\Http\Response;
 
 class ProductAnalyticsDashboardController extends Controller
 {
     private const ALLOWED_PERIODS = [7, 30, 90];
 
-    public function __invoke(Request $request, ProductAnalyticsDashboardService $dashboard): View
+    public function __invoke(Request $request, ProductAnalyticsDashboardService $dashboard): Response
     {
         $periodDays = (int) $request->integer('period', 30);
 
@@ -19,9 +19,13 @@ class ProductAnalyticsDashboardController extends Controller
             $periodDays = 30;
         }
 
-        return view('admin.analytics-dashboard', [
+        return response()->view('admin.analytics-dashboard', [
             'summary' => $dashboard->summarize($periodDays),
             'periods' => self::ALLOWED_PERIODS,
+        ])->withHeaders([
+            'Cache-Control' => 'no-store, no-cache, must-revalidate',
+            'Pragma' => 'no-cache',
+            'X-Robots-Tag' => 'noindex, nofollow, noarchive',
         ]);
     }
 }

--- a/app/Http/Middleware/EnsureAdminBasicAuth.php
+++ b/app/Http/Middleware/EnsureAdminBasicAuth.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureAdminBasicAuth
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $expectedUsername = config('admin.username');
+        $expectedPassword = config('admin.password');
+
+        if (! is_string($expectedUsername) || ! is_string($expectedPassword)) {
+            return $this->deny();
+        }
+
+        if (trim($expectedUsername) === '' || trim($expectedPassword) === '') {
+            return $this->deny();
+        }
+
+        $username = $request->getUser();
+        $password = $request->getPassword();
+
+        if (! is_string($username) || ! is_string($password)) {
+            return $this->deny();
+        }
+
+        if (! hash_equals($expectedUsername, $username) || ! hash_equals($expectedPassword, $password)) {
+            return $this->deny();
+        }
+
+        return $next($request);
+    }
+
+    private function deny(): Response
+    {
+        return response('Authentication required.', Response::HTTP_UNAUTHORIZED, [
+            'WWW-Authenticate' => 'Basic realm="Rock Code Labs Admin"',
+        ]);
+    }
+}

--- a/app/Services/Analytics/ProductAnalyticsDashboardService.php
+++ b/app/Services/Analytics/ProductAnalyticsDashboardService.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Services\Analytics;
+
+use App\Models\ProductAnalyticsEvent;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class ProductAnalyticsDashboardService
+{
+    private const TOP_LIMIT = 5;
+
+    /**
+     * @return array{
+     *     periodDays: int,
+     *     totalEvents: int,
+     *     eventsByDay: Collection<int, object>,
+     *     topPages: Collection<int, object>,
+     *     topTools: Collection<int, object>,
+     *     topCtas: Collection<int, object>,
+     *     topProjects: Collection<int, object>,
+     *     hasEvents: bool
+     * }
+     */
+    public function summarize(int $periodDays): array
+    {
+        $periodStart = now()->subDays($periodDays - 1)->startOfDay();
+        $baseQuery = ProductAnalyticsEvent::query()
+            ->where('occurred_at', '>=', $periodStart);
+
+        $totalEvents = (clone $baseQuery)->count();
+
+        return [
+            'periodDays' => $periodDays,
+            'totalEvents' => $totalEvents,
+            'eventsByDay' => $this->eventsByDay($periodStart),
+            'topPages' => $this->topPages($periodStart),
+            'topTools' => $this->topByColumn($periodStart, 'feature', ['tool_card_clicked', 'tool_opened']),
+            'topCtas' => $this->topByColumn($periodStart, 'destination', ['cta_clicked']),
+            'topProjects' => $this->topByColumn($periodStart, 'destination', ['project_card_clicked']),
+            'hasEvents' => $totalEvents > 0,
+        ];
+    }
+
+    /**
+     * @return Collection<int, object>
+     */
+    private function eventsByDay(Carbon $periodStart): Collection
+    {
+        return ProductAnalyticsEvent::query()
+            ->selectRaw('DATE(occurred_at) as label, COUNT(*) as total')
+            ->where('occurred_at', '>=', $periodStart)
+            ->groupBy(DB::raw('DATE(occurred_at)'))
+            ->orderBy('label')
+            ->get();
+    }
+
+    /**
+     * @return Collection<int, object>
+     */
+    private function topPages(Carbon $periodStart): Collection
+    {
+        return ProductAnalyticsEvent::query()
+            ->selectRaw('page_path as label, COUNT(*) as total')
+            ->where('occurred_at', '>=', $periodStart)
+            ->whereNotNull('page_path')
+            ->where('page_path', '!=', '')
+            ->groupBy('page_path')
+            ->orderByDesc('total')
+            ->orderBy('label')
+            ->limit(self::TOP_LIMIT)
+            ->get();
+    }
+
+    /**
+     * @param  list<string>  $eventNames
+     * @return Collection<int, object>
+     */
+    private function topByColumn(Carbon $periodStart, string $column, array $eventNames): Collection
+    {
+        return ProductAnalyticsEvent::query()
+            ->selectRaw($column.' as label, COUNT(*) as total')
+            ->where('occurred_at', '>=', $periodStart)
+            ->whereIn('event_name', $eventNames)
+            ->whereNotNull($column)
+            ->where($column, '!=', '')
+            ->groupBy($column)
+            ->orderByDesc('total')
+            ->orderBy('label')
+            ->limit(self::TOP_LIMIT)
+            ->get();
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\EnsureAdminBasicAuth;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -12,6 +13,10 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
+        $middleware->alias([
+            'admin.basic' => EnsureAdminBasicAuth::class,
+        ]);
+
         $trustedProxies = trim((string) env('TRUSTED_PROXIES', ''));
 
         if ($trustedProxies !== '') {

--- a/config/admin.php
+++ b/config/admin.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'username' => env('ADMIN_USERNAME'),
+    'password' => env('ADMIN_PASSWORD'),
+];

--- a/docs/admin-dashboard.md
+++ b/docs/admin-dashboard.md
@@ -1,0 +1,34 @@
+# Admin dashboard
+
+Dashboard interno mínimo para acompanhar eventos agregados de produto em `/admin`.
+
+## Autenticação
+
+O acesso usa HTTP Basic Auth com credenciais definidas no ambiente:
+
+- `ADMIN_USERNAME`
+- `ADMIN_PASSWORD`
+
+Se qualquer credencial estiver vazia ou incorreta, o acesso é bloqueado com `401`.
+
+## Dados exibidos
+
+O dashboard exibe somente dados agregados:
+
+- total de eventos;
+- eventos por dia;
+- top páginas;
+- top ferramentas;
+- top CTAs;
+- top projetos/apps clicados.
+
+Não são exibidos `session_id`, `metadata` ou eventos individuais.
+
+## Roteiro manual de teste
+
+1. Definir `ADMIN_USERNAME` e `ADMIN_PASSWORD` no ambiente.
+2. Acessar `/admin` sem credenciais e confirmar bloqueio `401`.
+3. Acessar `/admin` com credenciais válidas e confirmar abertura da dashboard.
+4. Enviar alguns eventos para `/api/analytics/events`.
+5. Reabrir `/admin` e conferir totais, rankings e filtros de 7, 30 e 90 dias.
+6. Confirmar que não aparecem dados individuais de sessão ou metadados.

--- a/docs/admin-dashboard.md
+++ b/docs/admin-dashboard.md
@@ -1,15 +1,26 @@
 # Admin dashboard
 
-Dashboard interno mínimo para acompanhar eventos agregados de produto em `/admin`.
+Dashboard interno minimo para acompanhar eventos agregados de produto em `/admin`.
 
-## Autenticação
+## Autenticacao
 
 O acesso usa HTTP Basic Auth com credenciais definidas no ambiente:
 
 - `ADMIN_USERNAME`
 - `ADMIN_PASSWORD`
 
-Se qualquer credencial estiver vazia ou incorreta, o acesso é bloqueado com `401`.
+Se qualquer credencial estiver vazia ou incorreta, o acesso e bloqueado com `401`.
+
+Em producao, use este admin somente com HTTPS ativo. HTTP Basic Auth nao deve ser exposto em HTTP puro.
+
+Se o ambiente usar cache de configuracao, altere as credenciais e regenere o cache conforme o fluxo de deploy:
+
+```text
+php artisan config:clear
+php artisan config:cache
+```
+
+O navegador pode manter credenciais Basic Auth em cache durante a sessao; trate isso como limitacao operacional do MVP.
 
 ## Dados exibidos
 
@@ -17,18 +28,29 @@ O dashboard exibe somente dados agregados:
 
 - total de eventos;
 - eventos por dia;
-- top páginas;
+- top paginas;
 - top ferramentas;
 - top CTAs;
 - top projetos/apps clicados.
 
-Não são exibidos `session_id`, `metadata` ou eventos individuais.
+Nao sao exibidos `session_id`, `metadata` ou eventos individuais.
+
+## Protecoes da resposta
+
+A rota `/admin` envia headers para reduzir cache e indexacao:
+
+- `Cache-Control: must-revalidate, no-cache, no-store, private`
+- `Pragma: no-cache`
+- `X-Robots-Tag: noindex, nofollow, noarchive`
+
+Como camada adicional fora da aplicacao, avalie Cloudflare Access, allowlist de IP, Nginx ou rate limit no edge se o admin ficar exposto publicamente.
 
 ## Roteiro manual de teste
 
 1. Definir `ADMIN_USERNAME` e `ADMIN_PASSWORD` no ambiente.
 2. Acessar `/admin` sem credenciais e confirmar bloqueio `401`.
-3. Acessar `/admin` com credenciais válidas e confirmar abertura da dashboard.
+3. Acessar `/admin` com credenciais validas e confirmar abertura da dashboard.
 4. Enviar alguns eventos para `/api/analytics/events`.
 5. Reabrir `/admin` e conferir totais, rankings e filtros de 7, 30 e 90 dias.
-6. Confirmar que não aparecem dados individuais de sessão ou metadados.
+6. Confirmar que nao aparecem dados individuais de sessao ou metadados.
+7. Confirmar que o acesso publico ocorre somente via HTTPS.

--- a/resources/views/admin/analytics-dashboard.blade.php
+++ b/resources/views/admin/analytics-dashboard.blade.php
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Admin - Rock Code Labs</title>
+    <style>
+        :root {
+            color: #1f2933;
+            background: #f4f6f8;
+            font-family: Arial, Helvetica, sans-serif;
+        }
+
+        body {
+            margin: 0;
+        }
+
+        main {
+            margin: 0 auto;
+            max-width: 1120px;
+            padding: 32px 20px 48px;
+        }
+
+        header {
+            align-items: flex-start;
+            display: flex;
+            gap: 16px;
+            justify-content: space-between;
+            margin-bottom: 24px;
+        }
+
+        h1 {
+            font-size: 28px;
+            margin: 0 0 8px;
+        }
+
+        p {
+            color: #52606d;
+            line-height: 1.5;
+            margin: 0;
+        }
+
+        nav {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+        }
+
+        nav a {
+            background: #ffffff;
+            border: 1px solid #d9e2ec;
+            border-radius: 6px;
+            color: #334e68;
+            padding: 8px 12px;
+            text-decoration: none;
+        }
+
+        nav a[aria-current="true"] {
+            background: #1f2933;
+            border-color: #1f2933;
+            color: #ffffff;
+        }
+
+        .notice,
+        .empty {
+            background: #ffffff;
+            border: 1px solid #d9e2ec;
+            border-radius: 8px;
+            margin-bottom: 20px;
+            padding: 16px;
+        }
+
+        .grid {
+            display: grid;
+            gap: 16px;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            margin-bottom: 20px;
+        }
+
+        .card {
+            background: #ffffff;
+            border: 1px solid #d9e2ec;
+            border-radius: 8px;
+            padding: 18px;
+        }
+
+        .card h2 {
+            color: #52606d;
+            font-size: 14px;
+            font-weight: 700;
+            margin: 0 0 12px;
+            text-transform: uppercase;
+        }
+
+        .metric {
+            color: #102a43;
+            font-size: 34px;
+            font-weight: 700;
+        }
+
+        table {
+            border-collapse: collapse;
+            width: 100%;
+        }
+
+        th,
+        td {
+            border-bottom: 1px solid #edf2f7;
+            padding: 10px 0;
+            text-align: left;
+            vertical-align: top;
+        }
+
+        th:last-child,
+        td:last-child {
+            text-align: right;
+        }
+
+        .muted {
+            color: #829ab1;
+        }
+
+        @media (max-width: 720px) {
+            header {
+                display: block;
+            }
+
+            nav {
+                margin-top: 16px;
+            }
+        }
+    </style>
+</head>
+<body>
+<main>
+    <header>
+        <div>
+            <h1>Dashboard interno</h1>
+            <p>Dados agregados e estimativos de eventos de produto da Rock Code Labs.</p>
+        </div>
+
+        <nav aria-label="Período">
+            @foreach ($periods as $period)
+                <a href="{{ route('admin.analytics', ['period' => $period]) }}" aria-current="{{ $summary['periodDays'] === $period ? 'true' : 'false' }}">
+                    {{ $period }} dias
+                </a>
+            @endforeach
+        </nav>
+    </header>
+
+    <section class="notice">
+        <p>Uso interno. Esta página mostra apenas contagens agregadas e não exibe sessões, metadados ou dados digitados por usuários.</p>
+    </section>
+
+    @if (! $summary['hasEvents'])
+        <section class="empty">
+            <h2>Nenhum evento encontrado</h2>
+            <p>Ainda não há eventos persistidos para o período selecionado.</p>
+        </section>
+    @endif
+
+    <section class="grid">
+        <article class="card">
+            <h2>Total de eventos</h2>
+            <div class="metric">{{ number_format($summary['totalEvents'], 0, ',', '.') }}</div>
+        </article>
+
+        <article class="card">
+            <h2>Período</h2>
+            <div class="metric">{{ $summary['periodDays'] }}</div>
+            <p class="muted">dias analisados</p>
+        </article>
+    </section>
+
+    <section class="grid">
+        @include('admin.partials.analytics-table', [
+            'title' => 'Eventos por dia',
+            'rows' => $summary['eventsByDay'],
+            'empty' => 'Sem eventos por dia.',
+        ])
+
+        @include('admin.partials.analytics-table', [
+            'title' => 'Top páginas',
+            'rows' => $summary['topPages'],
+            'empty' => 'Sem páginas registradas.',
+        ])
+
+        @include('admin.partials.analytics-table', [
+            'title' => 'Top ferramentas',
+            'rows' => $summary['topTools'],
+            'empty' => 'Sem ferramentas registradas.',
+        ])
+
+        @include('admin.partials.analytics-table', [
+            'title' => 'Top CTAs',
+            'rows' => $summary['topCtas'],
+            'empty' => 'Sem CTAs registrados.',
+        ])
+
+        @include('admin.partials.analytics-table', [
+            'title' => 'Top projetos/apps',
+            'rows' => $summary['topProjects'],
+            'empty' => 'Sem projetos ou apps registrados.',
+        ])
+    </section>
+</main>
+</body>
+</html>

--- a/resources/views/admin/analytics-dashboard.blade.php
+++ b/resources/views/admin/analytics-dashboard.blade.php
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow, noarchive">
     <title>Admin - Rock Code Labs</title>
     <style>
         :root {

--- a/resources/views/admin/partials/analytics-table.blade.php
+++ b/resources/views/admin/partials/analytics-table.blade.php
@@ -1,0 +1,24 @@
+<article class="card">
+    <h2>{{ $title }}</h2>
+
+    @if ($rows->isEmpty())
+        <p class="muted">{{ $empty }}</p>
+    @else
+        <table>
+            <thead>
+            <tr>
+                <th>Item</th>
+                <th>Total</th>
+            </tr>
+            </thead>
+            <tbody>
+            @foreach ($rows as $row)
+                <tr>
+                    <td>{{ $row->label }}</td>
+                    <td>{{ number_format($row->total, 0, ',', '.') }}</td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
+    @endif
+</article>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,12 @@
 <?php
 
+use App\Http\Controllers\Admin\ProductAnalyticsDashboardController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('index');
 });
+
+Route::get('/admin', ProductAnalyticsDashboardController::class)
+    ->middleware('admin.basic')
+    ->name('admin.analytics');

--- a/tests/Feature/AdminProductAnalyticsDashboardTest.php
+++ b/tests/Feature/AdminProductAnalyticsDashboardTest.php
@@ -79,6 +79,9 @@ class AdminProductAnalyticsDashboardTest extends TestCase
 
         $this->getWithAdminAuth('/admin')
             ->assertOk()
+            ->assertHeader('Cache-Control', 'must-revalidate, no-cache, no-store, private')
+            ->assertHeader('Pragma', 'no-cache')
+            ->assertHeader('X-Robots-Tag', 'noindex, nofollow, noarchive')
             ->assertSee('Total de eventos')
             ->assertSee('4')
             ->assertSee('2026-06-30')
@@ -104,6 +107,24 @@ class AdminProductAnalyticsDashboardTest extends TestCase
             ->assertSee('Ainda não há eventos persistidos para o período selecionado.')
             ->assertSee('Total de eventos')
             ->assertSee('0');
+    }
+
+    public function test_admin_dashboard_uses_default_period_when_period_is_invalid(): void
+    {
+        config([
+            'admin.username' => 'admin',
+            'admin.password' => 'secret',
+        ]);
+
+        $this->getWithAdminAuth('/admin?period=365')
+            ->assertOk()
+            ->assertSee('30')
+            ->assertDontSee('365 dias analisados');
+
+        $this->getWithAdminAuth('/admin?period=abc')
+            ->assertOk()
+            ->assertSee('30')
+            ->assertDontSee('abc');
     }
 
     private function getWithAdminAuth(string $uri): \Illuminate\Testing\TestResponse

--- a/tests/Feature/AdminProductAnalyticsDashboardTest.php
+++ b/tests/Feature/AdminProductAnalyticsDashboardTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ProductAnalyticsEvent;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminProductAnalyticsDashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_dashboard_blocks_unauthenticated_access(): void
+    {
+        config([
+            'admin.username' => 'admin',
+            'admin.password' => 'secret',
+        ]);
+
+        $this->get('/admin')
+            ->assertUnauthorized()
+            ->assertHeader('WWW-Authenticate', 'Basic realm="Rock Code Labs Admin"');
+    }
+
+    public function test_admin_dashboard_blocks_access_when_credentials_are_not_configured(): void
+    {
+        config([
+            'admin.username' => '',
+            'admin.password' => '',
+        ]);
+
+        $this->withHeaders([
+            'Authorization' => 'Basic '.base64_encode(':'),
+        ])->get('/admin')
+            ->assertUnauthorized();
+    }
+
+    public function test_admin_dashboard_displays_basic_aggregates(): void
+    {
+        config([
+            'admin.username' => 'admin',
+            'admin.password' => 'secret',
+        ]);
+
+        $this->travelTo('2026-06-30 12:00:00');
+
+        ProductAnalyticsEvent::query()->create([
+            'project' => 'rockcode-site',
+            'event_name' => 'page_viewed',
+            'page_path' => '/',
+            'session_id' => 'session-private',
+            'metadata' => ['variant' => 'private'],
+            'occurred_at' => now(),
+        ]);
+
+        ProductAnalyticsEvent::query()->create([
+            'project' => 'rockcode-site',
+            'event_name' => 'cta_clicked',
+            'destination' => 'contact_cta',
+            'page_path' => '/',
+            'occurred_at' => now(),
+        ]);
+
+        ProductAnalyticsEvent::query()->create([
+            'project' => 'rockcode-site',
+            'event_name' => 'tool_opened',
+            'feature' => 'base64',
+            'page_path' => '/ferramentas/base64',
+            'occurred_at' => now(),
+        ]);
+
+        ProductAnalyticsEvent::query()->create([
+            'project' => 'rockcode-site',
+            'event_name' => 'project_card_clicked',
+            'destination' => 'controle-financeiro',
+            'page_path' => '/apps',
+            'occurred_at' => now(),
+        ]);
+
+        $this->getWithAdminAuth('/admin')
+            ->assertOk()
+            ->assertSee('Total de eventos')
+            ->assertSee('4')
+            ->assertSee('2026-06-30')
+            ->assertSee('/')
+            ->assertSee('base64')
+            ->assertSee('contact_cta')
+            ->assertSee('controle-financeiro')
+            ->assertDontSee('session-private')
+            ->assertDontSee('variant')
+            ->assertDontSee('private');
+    }
+
+    public function test_admin_dashboard_displays_empty_state(): void
+    {
+        config([
+            'admin.username' => 'admin',
+            'admin.password' => 'secret',
+        ]);
+
+        $this->getWithAdminAuth('/admin')
+            ->assertOk()
+            ->assertSee('Nenhum evento encontrado')
+            ->assertSee('Ainda não há eventos persistidos para o período selecionado.')
+            ->assertSee('Total de eventos')
+            ->assertSee('0');
+    }
+
+    private function getWithAdminAuth(string $uri): \Illuminate\Testing\TestResponse
+    {
+        return $this->withHeaders([
+            'Authorization' => 'Basic '.base64_encode('admin:secret'),
+        ])->get($uri);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds protected /admin dashboard with HTTP Basic Auth configured by ADMIN_USERNAME and ADMIN_PASSWORD.
- Shows aggregate analytics only: total events, events by day, top pages, tools, CTAs, and clicked projects/apps.
- Adds empty state, admin setup docs, and manual test roadmap.

## Tests
- php artisan test
- vendor\\bin\\pint --dirty

Closes #3