### PR TITLE
docs: mark legacy backend as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-Projeto back-end API para site www.rockcodelabs.com.br
+# Rock Code Site API
+
+> [!WARNING]
+> **Projeto depreciado:** este backend foi substituído pela versão atual baseada em Inertia. Não utilize este repositório para novos desenvolvimentos ou deploys.
+
+Projeto back-end legado da Rock Code Labs.


### PR DESCRIPTION
## Summary
- marks the legacy backend as deprecated
- clarifies that the Inertia-based version is the current implementation
- advises against new development and deployments from this repository

## Validation
- git diff --check